### PR TITLE
Added release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+# Builds and pushes a docker image on a new tag.
+#
+# Uses the action:
+# https://github.com/marketplace/actions/build-and-push-docker-images
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Process repository information
+        id: vars
+        run: |
+          echo ::set-output name=image::${GITHUB_REPOSITORY#CCI-MOC/}
+          echo ::set-output name=tag::${GITHUB_REF#refs/tags/v}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: massopencloud/${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.tag }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Release workflow is based on
https://github.com/CCI-MOC/adjutant-moc/blob/015de325dced135f56867c2ca8e07814cc950e36/.github/workflows/release.yaml

Closes #7 