### PR TITLE
Fix EULA link

### DIFF
--- a/theme/moc/login/terms.ftl
+++ b/theme/moc/login/terms.ftl
@@ -4,7 +4,7 @@
         ${msg("termsTitle")}
     <#elseif section = "form">
     <div id="kc-terms-text">
-        I have read and agree to the terms presented in the <a href="https://massopen.cloud/moc_eula.pdf">Terms and Conditions</a>.
+        I have read and agree to the terms presented in the <a href="https://massopen.cloud/wp-content/uploads/2020/04/moc_eula1.pdf">Terms and Conditions</a>.
     </div>
     <form class="form-actions" action="${url.loginAction}" method="POST">
         <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" name="accept" id="kc-accept" type="submit" value="${msg("doAccept")}"/>


### PR DESCRIPTION
In the transition from self-hosted wordpress to managed wordpress, the url of the EULA changed.